### PR TITLE
add MaxKeySize option test, remove duplicated MaxCacheSize option test

### DIFF
--- a/expirable_cache_test.go
+++ b/expirable_cache_test.go
@@ -88,8 +88,8 @@ func TestExpirableCache_BadOptions(t *testing.T) {
 	_, err := NewExpirableCache(MaxCacheSize(-1))
 	assert.EqualError(t, err, "failed to set cache option: negative max cache size")
 
-	_, err = NewExpirableCache(MaxCacheSize(-1))
-	assert.EqualError(t, err, "failed to set cache option: negative max cache size")
+	_, err = NewExpirableCache(MaxKeySize(-1))
+	assert.EqualError(t, err, "failed to set cache option: negative max key size")
 
 	_, err = NewExpirableCache(MaxKeys(-1))
 	assert.EqualError(t, err, "failed to set cache option: negative max keys")

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -62,8 +62,8 @@ func TestLruCache_BadOptions(t *testing.T) {
 	_, err := NewLruCache(MaxCacheSize(-1))
 	assert.EqualError(t, err, "failed to set cache option: negative max cache size")
 
-	_, err = NewLruCache(MaxCacheSize(-1))
-	assert.EqualError(t, err, "failed to set cache option: negative max cache size")
+	_, err = NewLruCache(MaxKeySize(-1))
+	assert.EqualError(t, err, "failed to set cache option: negative max key size")
 
 	_, err = NewLruCache(MaxKeys(-1))
 	assert.EqualError(t, err, "failed to set cache option: negative max keys")


### PR DESCRIPTION
Both [lru_cache_test.go](https://github.com/go-pkgz/lcw/blob/master/lru_cache_test.go#L65) and [expirable_cache_test.go](https://github.com/go-pkgz/lcw/blob/master/expirable_cache_test.go#L92) contain duplicated negative `MaxCacheSize` option test, but negative [maxKeySize](https://github.com/go-pkgz/lcw/blob/master/options.go#L11) option test is missing, which is a mistake, I assume, since it also [can't be negative](https://github.com/go-pkgz/lcw/blob/master/options.go#L34)