### PR TITLE
Rewrite internal cache package for lcw requirements

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,63 +1,52 @@
-// Package cache implements LoadingCache similar to Guava's cache.
+// Package cache implements LoadingCache.
 //
-// Usual way is to use Get(key, ttl, func loader), but direct access to values
-// possible with GetValue. Cache also keeps stats and exposes it with Stat method.
-// Supported size-based eviction with LRC and LRU, and TTL based eviction.
+// Support size-based eviction with LRC and LRU, and TTL based eviction.
 package cache
 
 import (
-	"fmt"
-	"log"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
-// LoadingCache defines loading cache interface
-type LoadingCache interface {
-	fmt.Stringer
-	Get(key string, ttl time.Duration, fn func() (data interface{}, err error)) (interface{}, error)
-	GetValue(key string) (interface{}, bool)
-	Invalidate(key string)
-	InvalidateFn(fn func(key string) bool)
-	Stat() Stats
-}
-
-// loadingCacheImpl provides loading cache with on-demand loading, similar to Guava LoadingCache.
+// LoadingCache provides loading cache with on-demand loading, similar to Guava LoadingCache.
 // Implements cache.LoadingCache. Cache is consistent, i.e. read guaranteed to get latest write,
 // and no stale writes in any place. In order to provide such
-// consistency loadingCacheImpl locking on particular key, but no locks across multiple keys.
-type loadingCacheImpl struct {
+// consistency LoadingCache locking on particular key, but no locks across multiple keys.
+type LoadingCache struct {
 	purgeEvery time.Duration
-	maxKeys    int
-	allowError bool
+	ttl        time.Duration
+	maxKeys    int64
 	isLRU      bool
+	done       chan struct{}
+	onEvicted  func(key string, value interface{})
 
 	sync.Mutex
-	stat Stats
 	data map[string]*cacheItem
 }
 
-// Stats provides statistics for cache
-type Stats struct {
-	Size           int // number of records in cache
-	Hits, Misses   int // cache effectiveness
-	Added, Evicted int // number of added and auto-evicted records
-}
-
+// noEvictionTTL - very long ttl to prevent eviction
 const noEvictionTTL = time.Hour * 24 * 365 * 10
 
-// NewLoadingCache returns a new cache, activates purge with purgeEvery (0 to never purge)
-func NewLoadingCache(options ...Option) LoadingCache {
-	res := loadingCacheImpl{
+// allKeys - LoadingCache.purge() maxKeys value for clearing the storage
+const allKeys = -1
+
+// NewLoadingCache returns a new cache, activates purge with purgeEvery (0 to never purge).
+// Default MaxKeys is unlimited (0).
+func NewLoadingCache(options ...Option) (*LoadingCache, error) {
+	res := LoadingCache{
 		data:       map[string]*cacheItem{},
+		ttl:        noEvictionTTL,
 		purgeEvery: 0,
 		maxKeys:    0,
+		done:       make(chan struct{}),
 	}
 
 	for _, opt := range options {
 		if err := opt(&res); err != nil {
-			log.Printf("[WARN] failed to set cache option, %v", err)
+			return nil, errors.Wrap(err, "failed to set cache option")
 		}
 	}
 
@@ -65,93 +54,147 @@ func NewLoadingCache(options ...Option) LoadingCache {
 		if res.purgeEvery == 0 {
 			res.purgeEvery = time.Minute * 5 // non-zero purge enforced because maxKeys defined
 		}
-		go func() {
+		go func(done <-chan struct{}) {
 			ticker := time.NewTicker(res.purgeEvery)
-			for range ticker.C {
-				res.Lock()
-				res.purge(res.maxKeys)
-				res.Unlock()
+			for {
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+					res.Lock()
+					res.purge(res.maxKeys)
+					res.Unlock()
+				}
 			}
-		}()
+		}(res.done)
 	}
-	log.Printf("[DEBUG] cache created. purge=%v, max=%d", res.purgeEvery, res.maxKeys)
-	return &res
+	return &res, nil
 }
 
-// Get by key if found, or get value and return
-func (c *loadingCacheImpl) Get(key string, ttl time.Duration, f func() (interface{}, error)) (interface{}, error) {
-
-	c.Lock()
-	var ci *cacheItem
-	if ci = c.data[key]; ci == nil {
-
-		itemTTL := ttl
-		if ttl == 0 {
-			itemTTL = noEvictionTTL // very long ttl to prevent eviction
-		}
-
-		ci = &cacheItem{fun: f, ttl: itemTTL}
-		c.data[key] = ci
-		c.stat.Added++
-	}
-	c.Unlock()
-
-	// we don't want to block the possible call as this may take time
-	// and also cause dead-lock if one cached value calls (the same cache) for another
-	data, called, err := ci.value(c.allowError)
-
+// Set key
+func (c *LoadingCache) Set(key string, value interface{}) {
 	c.Lock()
 	defer c.Unlock()
-	c.stat.Size = len(c.data)
-	if called {
-		c.stat.Misses++
-	} else {
-		c.stat.Hits++
+
+	now := time.Now()
+	if _, ok := c.data[key]; !ok {
+		c.data[key] = &cacheItem{}
 	}
-	if c.maxKeys > 0 && c.stat.Size >= c.maxKeys*2 {
+	c.data[key].data = value
+	c.data[key].expiresAt = now.Add(c.ttl)
+	if c.isLRU {
+		c.data[key].lastReadAt = now
+	}
+
+	// Enforced purge call in addition the one from the ticker
+	// to limit the worst-case scenario with a lot of sets in the
+	// short period of time (between two timed purge calls)
+	if c.maxKeys > 0 && int64(len(c.data)) >= c.maxKeys*2 {
 		c.purge(c.maxKeys)
 	}
-	return data, err
 }
 
-// GetValue by key from cache
-func (c *loadingCacheImpl) GetValue(key string) (interface{}, bool) {
+// Get returns the key value
+func (c *LoadingCache) Get(key string) (interface{}, bool) {
 	c.Lock()
 	defer c.Unlock()
-	res, ok := c.data[key]
+	value, ok := c.getValue(key)
 	if !ok {
 		return nil, false
 	}
-	return res.data, ok
+	if c.isLRU {
+		c.data[key].lastReadAt = time.Now()
+	}
+	return value, ok
+}
+
+// Peek returns the key value (or undefined if not found) without updating the "recently used"-ness of the key.
+func (c *LoadingCache) Peek(key string) (interface{}, bool) {
+	c.Lock()
+	defer c.Unlock()
+	value, ok := c.getValue(key)
+	if !ok {
+		return nil, false
+	}
+	return value, ok
 }
 
 // Invalidate key (item) from the cache
-func (c *loadingCacheImpl) Invalidate(key string) {
+func (c *LoadingCache) Invalidate(key string) {
 	c.Lock()
-	delete(c.data, key)
+	if value, ok := c.data[key]; ok {
+		delete(c.data, key)
+		if c.onEvicted != nil {
+			c.onEvicted(key, value.data)
+		}
+	}
 	c.Unlock()
 }
 
 // InvalidateFn deletes multiple keys if predicate is true
-func (c *loadingCacheImpl) InvalidateFn(fn func(key string) bool) {
+func (c *LoadingCache) InvalidateFn(fn func(key string) bool) {
 	c.Lock()
-	for key := range c.data {
+	for key, value := range c.data {
 		if fn(key) {
 			delete(c.data, key)
+			if c.onEvicted != nil {
+				c.onEvicted(key, value.data)
+			}
 		}
 	}
 	c.Unlock()
 }
 
-// Stat gets the current stats for cache
-func (c *loadingCacheImpl) Stat() Stats {
+// Keys return slice of current keys in the cache
+func (c *LoadingCache) Keys() []string {
 	c.Lock()
 	defer c.Unlock()
-	return c.stat
+	keys := make([]string, 0, len(c.data))
+	for k := range c.data {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
-func (c *loadingCacheImpl) String() string {
-	return fmt.Sprintf("%+v (%0.1f%%)", c.Stat(), 100*float64(c.Stat().Hits)/float64(c.stat.Hits+c.stat.Misses))
+// get value respecting the expiration, should be called with lock
+func (c *LoadingCache) getValue(key string) (interface{}, bool) {
+	value, ok := c.data[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(c.data[key].expiresAt) {
+		return nil, false
+	}
+	return value.data, ok
+}
+
+// Purge clears the cache completely.
+func (c *LoadingCache) Purge() {
+	c.Lock()
+	defer c.Unlock()
+	c.purge(allKeys)
+}
+
+// DeleteExpired clears cache of expired items
+func (c *LoadingCache) DeleteExpired() {
+	c.Lock()
+	defer c.Unlock()
+	c.purge(0)
+}
+
+// ItemCount return count of items in cache
+func (c *LoadingCache) ItemCount() int {
+	c.Lock()
+	n := len(c.data)
+	c.Unlock()
+	return n
+}
+
+// Close cleans the cache and destroys running goroutines
+func (c *LoadingCache) Close() {
+	c.Lock()
+	defer c.Unlock()
+	close(c.done)
 }
 
 // keysWithTs includes list of keys with ts. This is for sorting keys
@@ -161,24 +204,25 @@ type keysWithTs []struct {
 	ts  time.Time
 }
 
-// purge records > max.size. Has to be called with lock!
-func (c *loadingCacheImpl) purge(maxKeys int) {
-
+// purge records > maxKeys. Has to be called with lock!
+// call with maxKeys 0 will only clear expired entries, with -1 will clear everything.
+func (c *LoadingCache) purge(maxKeys int64) {
 	kts := keysWithTs{}
 
-	for key, cacheItem := range c.data {
-
+	for key, value := range c.data {
 		// ttl eviction
-		if cacheItem.hasExpired() {
+		if time.Now().After(c.data[key].expiresAt) {
 			delete(c.data, key)
-			c.stat.Evicted++
+			if c.onEvicted != nil {
+				c.onEvicted(key, value.data)
+			}
 		}
 
 		// prepare list of keysWithTs for size eviction
-		if maxKeys > 0 && len(c.data) > maxKeys {
-			ts := cacheItem.expiresAt // for no-LRU sort by expiration time
-			if c.isLRU {              // for LRU sort by read time
-				ts = cacheItem.lastReadAt
+		if maxKeys == allKeys || (maxKeys > 0 && int64(len(c.data)) > maxKeys) {
+			ts := c.data[key].expiresAt // for no-LRU sort by expiration time
+			if c.isLRU {                // for LRU sort by read time
+				ts = c.data[key].lastReadAt
 			}
 
 			kts = append(kts, struct {
@@ -189,47 +233,25 @@ func (c *loadingCacheImpl) purge(maxKeys int) {
 	}
 
 	// size eviction
-	size := len(c.data)
+	size := int64(len(c.data))
+	if maxKeys == allKeys { // evict everything in case maxKeys == -1
+		maxKeys = 0
+	}
 	if len(kts) > 0 {
 		sort.Slice(kts, func(i int, j int) bool { return kts[i].ts.Before(kts[j].ts) })
-		for d := 0; d < size-maxKeys; d++ {
-			delete(c.data, kts[d].key)
-			c.stat.Evicted++
+		for d := 0; int64(d) < size-maxKeys; d++ {
+			key := kts[d].key
+			value := c.data[key].data
+			delete(c.data, key)
+			if c.onEvicted != nil {
+				c.onEvicted(key, value)
+			}
 		}
 	}
-	c.stat.Size = len(c.data)
 }
 
 type cacheItem struct {
-	sync.Mutex
-	fun        func() (data interface{}, err error)
 	expiresAt  time.Time
 	lastReadAt time.Time
-	ttl        time.Duration
 	data       interface{}
-	err        error
-}
-
-func (ci *cacheItem) value(allowError bool) (data interface{}, called bool, err error) {
-	ci.Lock()
-	defer ci.Unlock()
-	called = false
-	now := time.Now()
-	if ci.expiresAt.IsZero() || now.After(ci.expiresAt) {
-		ci.data, ci.err = ci.fun()
-		ci.expiresAt = now.Add(ci.ttl)
-
-		if ci.err != nil && !allowError { // don't cache error calls
-			ci.expiresAt = now
-		}
-		called = true
-	}
-	ci.lastReadAt = time.Now()
-	return ci.data, called, ci.err
-}
-
-func (ci *cacheItem) hasExpired() (b bool) {
-	ci.Lock()
-	defer ci.Unlock()
-	return !ci.expiresAt.IsZero() && time.Now().After(ci.expiresAt)
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,356 +1,210 @@
 package cache
 
 import (
-	"errors"
 	"fmt"
-	"log"
-	"math/rand"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLoadingCacheNoPurge(t *testing.T) {
-	var lc LoadingCache
-	lc = NewLoadingCache()
+	lc, err := NewLoadingCache()
+	assert.NoError(t, err)
 
-	called := 0
-	v, err := lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
+	lc.Set("key1", "val1")
+	assert.Equal(t, 1, lc.ItemCount())
 
-	assert.Nil(t, err)
+	v, ok := lc.Peek("key1")
 	assert.Equal(t, "val1", v)
-	assert.Equal(t, 1, called)
+	assert.True(t, ok)
 
-	v, err = lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-	assert.Equal(t, 1, called)
+	v, ok = lc.Peek("key2")
+	assert.Empty(t, v)
+	assert.False(t, ok)
 
-	v, err = lc.Get("key2", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val2", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val2", v)
-	assert.Equal(t, 2, called)
-	assert.Equal(t, 2, lc.Stat().Size)
+	assert.Equal(t, []string{"key1"}, lc.Keys())
 }
 
 func TestLoadingCacheWithPurge(t *testing.T) {
-	lc := NewLoadingCache(PurgeEvery(time.Millisecond * 50))
-	called := 0
+	var evicted []string
+	lc, err := NewLoadingCache(
+		LRU(),
+		PurgeEvery(time.Millisecond*100),
+		TTL(150*time.Millisecond),
+		OnEvicted(func(key string, value interface{}) { evicted = append(evicted, key, value.(string)) }),
+	)
+	assert.NoError(t, err)
+	defer lc.Close()
 
-	v, err := lc.Get("key1", 150*time.Millisecond, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-	assert.Nil(t, err)
+	lc.Set("key1", "val1")
+
+	time.Sleep(100 * time.Millisecond) // not enough to expire
+	assert.Equal(t, 1, lc.ItemCount())
+
+	v, ok := lc.Get("key1")
 	assert.Equal(t, "val1", v)
-	assert.Equal(t, 1, called)
+	assert.True(t, ok)
 
-	time.Sleep(100 * time.Millisecond) // not enougth to expire
-	assert.Equal(t, 1, lc.Stat().Size)
+	time.Sleep(200 * time.Millisecond) // expire
+	v, ok = lc.Get("key1")
+	assert.False(t, ok)
+	assert.Nil(t, v)
 
-	v, err = lc.Get("key1", 150*time.Millisecond, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-	assert.Equal(t, 1, called)
+	assert.Equal(t, 0, lc.ItemCount())
+	assert.Equal(t, []string{"key1", "val1"}, evicted)
 
-	time.Sleep(200 * time.Millisecond) //expire
-	v, err = lc.Get("key1", 150*time.Millisecond, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-	assert.Equal(t, 2, called, "second call")
+	// add new entry
+	lc.Set("key2", "val2")
+	assert.Equal(t, 1, lc.ItemCount())
 
-	assert.Equal(t, 1, lc.Stat().Size)
-	t.Log(lc)
+	// DeleteExpired, nothing deleted
+	lc.DeleteExpired()
+	assert.Equal(t, 1, lc.ItemCount())
+	assert.Equal(t, []string{"key1", "val1"}, evicted)
+
+	// Purge, cache should be clean
+	lc.Purge()
+	assert.Equal(t, 0, lc.ItemCount())
+	assert.Equal(t, []string{"key1", "val1", "key2", "val2"}, evicted)
 }
 
 func TestLoadingCacheWithPurgeEnforcedBySize(t *testing.T) {
-	lc := NewLoadingCache(PurgeEvery(time.Hour), MaxKeys(10))
-	called := 0
+	lc, err := NewLoadingCache(MaxKeys(10))
+	assert.NoError(t, err)
+	defer lc.Close()
 
 	for i := 0; i < 100; i++ {
-		v, err := lc.Get(fmt.Sprintf("key%d", i), 150*time.Millisecond, func() (data interface{}, err error) {
-			called++
-			return fmt.Sprintf("val%d", i), nil
-		})
-		assert.Nil(t, err)
+		i := i
+		lc.Set(fmt.Sprintf("key%d", i), fmt.Sprintf("val%d", i))
+		v, ok := lc.Get(fmt.Sprintf("key%d", i))
 		assert.Equal(t, fmt.Sprintf("val%d", i), v)
-		assert.True(t, lc.Stat().Size < 20)
+		assert.True(t, ok)
+		assert.True(t, lc.ItemCount() < 20)
 	}
 
-	assert.Equal(t, 100, called)
-	assert.Equal(t, 10, lc.Stat().Size)
-	assert.Equal(t, 90, lc.Stat().Evicted)
-}
-
-func TestLoadingCacheDelete(t *testing.T) {
-	lc := NewLoadingCache()
-
-	called := 0
-	v, err := lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-	assert.Equal(t, 1, called)
-
-	lc.Invalidate("key1")
-
-	v, err = lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-	assert.Equal(t, 2, called)
+	assert.Equal(t, 10, lc.ItemCount())
 }
 
 func TestLoadingCacheWithPurgeMax(t *testing.T) {
-	lc := NewLoadingCache(PurgeEvery(time.Millisecond*50), MaxKeys(2))
+	lc, err := NewLoadingCache(PurgeEvery(time.Millisecond*50), MaxKeys(2))
+	assert.NoError(t, err)
+	defer lc.Close()
 
-	called := 0
-
-	v, err := lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-	assert.Equal(t, 1, called)
-
-	v, err = lc.Get("key2", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val2", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val2", v)
-	assert.Equal(t, 2, called)
-
-	v, err = lc.Get("key3", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val3", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val3", v)
-	assert.Equal(t, 3, called)
-
-	assert.Equal(t, 3, lc.Stat().Size)
+	lc.Set("key1", "val1")
+	lc.Set("key2", "val2")
+	lc.Set("key3", "val3")
+	assert.Equal(t, 3, lc.ItemCount())
 
 	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 2, lc.Stat().Size)
+	assert.Equal(t, 2, lc.ItemCount())
 
-	_, found := lc.GetValue("key1")
+	_, found := lc.Get("key1")
 	assert.False(t, found, "key1 should be deleted")
-	t.Logf("%+v", lc.Stat())
 }
 
 func TestLoadingCacheWithPurgeMaxLru(t *testing.T) {
-	lc := NewLoadingCache(PurgeEvery(time.Millisecond*50), MaxKeys(2), LRU())
+	lc, err := NewLoadingCache(PurgeEvery(time.Millisecond*50), MaxKeys(2), LRU())
+	assert.NoError(t, err)
+	defer lc.Close()
 
-	called := 0
-
-	v, err := lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val1", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-	assert.Equal(t, 1, called)
-
-	v, err = lc.Get("key2", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val2", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val2", v)
-	assert.Equal(t, 2, called)
-
-	v, err = lc.Get("key3", time.Minute, func() (data interface{}, err error) {
-		called++
-		return "val3", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val3", v)
-	assert.Equal(t, 3, called)
-
-	assert.Equal(t, 3, lc.Stat().Size)
+	lc.Set("key1", "val1")
+	lc.Set("key2", "val2")
+	lc.Set("key3", "val3")
+	assert.Equal(t, 3, lc.ItemCount())
 
 	// read key1 again, changes LRU
-	v, err = lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		assert.Fail(t, "should be cached already")
-		return "val1", nil
-	})
-	assert.Nil(t, err)
+	v, ok := lc.Get("key1")
 	assert.Equal(t, "val1", v)
+	assert.True(t, ok)
 
 	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 2, lc.Stat().Size)
+	assert.Equal(t, 2, lc.ItemCount())
 
-	_, found := lc.GetValue("key2")
+	_, found := lc.Get("key2")
 	assert.False(t, found, "key2 should be deleted")
-	t.Logf("%+v", lc.Stat())
 }
 
-func TestLoadingCacheStat(t *testing.T) {
-	lc := NewLoadingCache(PurgeEvery(time.Millisecond*10), MaxKeys(50)) //50 records max
-
-	// 10 distinct records, 20 hits for each one
-	for i := 0; i < 200; i++ {
-		v, err := lc.Get(fmt.Sprintf("key-%d", i%10), time.Millisecond*500, func() (data interface{}, err error) {
-			return "val", nil
-		})
-		assert.Nil(t, err)
-		assert.Equal(t, "val", v)
-		time.Sleep(1 * time.Millisecond)
-	}
-	assert.Equal(t, Stats{Size: 10, Hits: 190, Misses: 10, Added: 10, Evicted: 0}, lc.Stat())
-	t.Log(lc)
-
-	time.Sleep(500 * time.Millisecond) // let records to expire
-	assert.Equal(t, Stats{Size: 0, Hits: 190, Misses: 10, Added: 10, Evicted: 10}, lc.Stat())
-}
-
-func TestLoadingCacheConsistency(t *testing.T) {
-	lc := NewLoadingCache()
+func TestLoadingCacheConcurrency(t *testing.T) {
+	lc, err := NewLoadingCache()
+	assert.NoError(t, err)
 	wg := sync.WaitGroup{}
 	wg.Add(1000)
 	for i := 0; i < 1000; i++ {
 		go func(i int) {
-			_, e := lc.Get(fmt.Sprintf("key-%d", i/10), time.Minute, func() (data interface{}, err error) {
-				return fmt.Sprintf("val-%d", i/10), nil
-			})
-			assert.Nil(t, e)
+			lc.Set(fmt.Sprintf("key-%d", i/10), fmt.Sprintf("val-%d", i/10))
 			wg.Done()
 		}(i)
 	}
 	wg.Wait()
-	t.Log(lc)
-	assert.Equal(t, 900, lc.Stat().Hits)
+	assert.Equal(t, 100, lc.ItemCount())
 }
 
-func TestLoadingCacheConcurrentUpdate(t *testing.T) {
-	slowUpdate := func() (list []string) {
-		for i := 0; i < 100; i++ {
-			list = append(list, "string #"+strconv.Itoa(i))
-			d := rand.Int31n(1000)
-			if d > 800 {
-				time.Sleep(10 * time.Millisecond)
-			}
-		}
-		return list
-	}
+func TestLoadingCacheInvalidateAndEvict(t *testing.T) {
+	var evicted int
+	lc, err := NewLoadingCache(LRU(), OnEvicted(func(_ string, _ interface{}) { evicted++ }))
+	assert.NoError(t, err)
 
-	lc := NewLoadingCache(MaxKeys(10), PurgeEvery(time.Millisecond*1))
-	wg := sync.WaitGroup{}
-	wg.Add(100)
-	for i := 0; i < 100; i++ {
-		go func(i int) {
-			time.Sleep(10 * time.Millisecond)
-			r, e := lc.Get(fmt.Sprintf("key"), time.Millisecond*100, func() (data interface{}, err error) {
-				return slowUpdate(), nil
-			})
-			require.Nil(t, e)
-			assert.Equal(t, 100, len(r.([]string)))
-			wg.Done()
-		}(i)
-	}
-	wg.Wait()
-	t.Log(lc)
-}
+	lc.Set("key1", "val1")
+	lc.Set("key2", "val2")
 
-func TestLoadingCacheGetValue(t *testing.T) {
-	lc := NewLoadingCache()
-	v, err := lc.Get("key1", time.Minute, func() (data interface{}, err error) {
-		return "val1", nil
-	})
-	assert.Nil(t, err)
-	assert.Equal(t, "val1", v)
-
-	val, ok := lc.GetValue("key1")
+	val, ok := lc.Get("key1")
 	assert.True(t, ok)
 	assert.Equal(t, "val1", val)
+	assert.Equal(t, 0, evicted)
 
 	lc.Invalidate("key1")
-	_, ok = lc.GetValue("key1")
+	assert.Equal(t, 1, evicted)
+	val, ok = lc.Get("key1")
+	assert.Empty(t, val)
 	assert.False(t, ok)
-}
 
-func TestLoadingCacheWithErrorNotAllowed(t *testing.T) {
+	val, ok = lc.Get("key2")
+	assert.True(t, ok)
+	assert.Equal(t, "val2", val)
 
-	lc := NewLoadingCache(PurgeEvery(time.Hour*10), MaxKeys(50))
-	hits := 0
-	for i := 0; i < 10; i++ {
-		_, e := lc.Get("key", time.Hour, func() (data interface{}, err error) {
-			hits++
-			return nil, errors.New("errrr")
-		})
-		assert.NotNil(t, e)
-	}
-	assert.Equal(t, 10, hits, "all err hits not cached")
-
-	assert.Equal(t, 1, lc.Stat().Size)
-	assert.Equal(t, 0, lc.Stat().Hits)
-	assert.Equal(t, 10, lc.Stat().Misses)
-}
-
-func TestLoadingCacheWithErrorAllowed(t *testing.T) {
-
-	lc := NewLoadingCache(PurgeEvery(time.Hour*10), MaxKeys(50), AllowErrors())
-	hits := 0
-	for i := 0; i < 10; i++ {
-		_, _ = lc.Get("key", time.Hour, func() (data interface{}, err error) {
-			hits++
-			return nil, errors.New("errrr")
-		})
-	}
-	assert.Equal(t, 1, hits, "all err hits cached")
-
-	assert.Equal(t, 1, lc.Stat().Size)
-	assert.Equal(t, 9, lc.Stat().Hits)
-	assert.Equal(t, 1, lc.Stat().Misses)
-}
-
-func ExampleLoadingCache() {
-	// make cache with every 200ms purge and 3 max keys
-	cache := NewLoadingCache(PurgeEvery(time.Millisecond*200), MaxKeys(3))
-
-	// get value, store under key1 with TTL=1s
-	r, err := cache.Get("key1", time.Second, func() (data interface{}, err error) {
-		return "val1", nil
+	lc.InvalidateFn(func(key string) bool {
+		return key == "key2"
 	})
+	assert.Equal(t, 2, evicted)
+	_, ok = lc.Get("key2")
+	assert.False(t, ok)
+	assert.Equal(t, 0, lc.ItemCount())
+}
 
-	if err != nil { // check for nil before any type assertion
-		log.Fatal(err)
-	}
-
-	rstr := r.(string) // convert cached value from interface{} to real type
-	fmt.Print(rstr, " ")
-
-	// get from key1, won't hit cache func, not expired yet
-	r, _ = cache.Get("key1", time.Second, func() (data interface{}, err error) {
-		return "val2", nil
+func TestLoadingCacheBadOption(t *testing.T) {
+	lc, err := NewLoadingCache(func(lc *LoadingCache) error {
+		return errors.New("mock err")
 	})
-	fmt.Print(r, " ")
-	fmt.Printf("%+v\n", cache.Stat())
-	// Output: val1 val1 {Size:1 Hits:1 Misses:1 Added:1 Evicted:0}
+	assert.EqualError(t, err, "failed to set cache option: mock err")
+	assert.Nil(t, lc)
+}
+
+func TestLoadingExpired(t *testing.T) {
+	lc, err := NewLoadingCache(TTL(time.Millisecond * 5))
+	assert.NoError(t, err)
+
+	lc.Set("key1", "val1")
+	assert.Equal(t, 1, lc.ItemCount())
+
+	v, ok := lc.Peek("key1")
+	assert.Equal(t, v, "val1")
+	assert.True(t, ok)
+
+	v, ok = lc.Get("key1")
+	assert.Equal(t, v, "val1")
+	assert.True(t, ok)
+
+	time.Sleep(time.Millisecond * 10)  // wait for entry to expire
+	assert.Equal(t, 1, lc.ItemCount()) // but not purged
+
+	v, ok = lc.Peek("key1")
+	assert.Empty(t, v)
+	assert.False(t, ok)
+
+	v, ok = lc.Get("key1")
+	assert.Empty(t, v)
+	assert.False(t, ok)
 }


### PR DESCRIPTION
Simplify the logic, removing functions calls and storage. Stats removed as they are provided by lcw itself.