### PR TITLE
Switch LRU to internal cache implementation

### DIFF
--- a/expirable_cache_test.go
+++ b/expirable_cache_test.go
@@ -2,7 +2,6 @@ package lcw
 
 import (
 	"fmt"
-	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -27,7 +26,6 @@ func TestExpirableCache(t *testing.T) {
 	assert.Equal(t, int64(5), lc.Stat().Misses)
 
 	keys := lc.Keys()
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	assert.EqualValues(t, []string{"key-0", "key-1", "key-2", "key-3", "key-4"}, keys)
 
 	_, e := lc.Get("key-xx", func() (Value, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/alicebob/miniredis/v2 v2.11.4
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/hashicorp/go-multierror v1.1.0
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/internal/cache/options.go
+++ b/internal/cache/options.go
@@ -13,7 +13,7 @@ func OnEvicted(fn func(key string, value interface{})) Option {
 	}
 }
 
-// PurgeEvery functional option defines purge interval
+// PurgeEvery functional option defines deleteExpired interval
 // by default it is 0, i.e. never. If MaxKeys set to any non-zero this default will be 5minutes
 func PurgeEvery(interval time.Duration) Option {
 	return func(lc *LoadingCache) error {
@@ -41,7 +41,7 @@ func TTL(ttl time.Duration) Option {
 	}
 }
 
-// LRU sets cache to LRU (Least Recently Used) eviction mode. Affects size-based purge only.
+// LRU sets cache to LRU (Least Recently Used) eviction mode.
 func LRU() Option {
 	return func(lc *LoadingCache) error {
 		lc.isLRU = true

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"sort"
 	"sync/atomic"
 	"testing"
 
@@ -32,7 +31,6 @@ func TestLruCache_MaxKeys(t *testing.T) {
 	}
 
 	keys := lc.Keys()
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	assert.EqualValues(t, []string{"key-0", "key-1", "key-2", "key-3", "key-4"}, keys)
 
 	// check if really cached

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -48,7 +48,7 @@ func TestLruCache_MaxKeys(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "result-X", res.(string))
-	assert.Equal(t, 5, lc.backend.Len())
+	assert.Equal(t, 5, lc.backend.ItemCount())
 
 	// put to cache and make sure it cached
 	res, err = lc.Get("key-Z", func() (Value, error) {
@@ -62,7 +62,14 @@ func TestLruCache_MaxKeys(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "result-Z", res.(string), "got cached value")
-	assert.Equal(t, 5, lc.backend.Len())
+	assert.Equal(t, 5, lc.backend.ItemCount())
+
+	// first inserted item should be evicted by now
+	res, err = lc.Get("key-1", func() (Value, error) {
+		return "result-blah", nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "result-blah", res.(string), "should not be cached")
 }
 
 func TestLruCache_BadOptions(t *testing.T) {


### PR DESCRIPTION
This version is basically hybrid of ours and [hashicorp/golang-lru](https://github.com/hashicorp/golang-lru). It turned out we still support expirable LRU cache, we just don't use it in lcw yet.