### PR TITLE
Switch LRU to internal cache implementation, embeded list

### DIFF
--- a/expirable_cache_test.go
+++ b/expirable_cache_test.go
@@ -2,7 +2,6 @@ package lcw
 
 import (
 	"fmt"
-	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -27,7 +26,6 @@ func TestExpirableCache(t *testing.T) {
 	assert.Equal(t, int64(5), lc.Stat().Misses)
 
 	keys := lc.Keys()
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	assert.EqualValues(t, []string{"key-0", "key-1", "key-2", "key-3", "key-4"}, keys)
 
 	_, e := lc.Get("key-xx", func() (Value, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/alicebob/miniredis/v2 v2.11.4
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/hashicorp/go-multierror v1.1.0
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/internal/cache/list.go
+++ b/internal/cache/list.go
@@ -1,0 +1,131 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the lists_LICENSE file.
+
+package cache
+
+// Next returns the next list element or nil.
+func (e *cacheItem) Next() *cacheItem {
+	if p := e.next; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element or nil.
+func (e *cacheItem) Prev() *cacheItem {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// list represents a doubly linked list.
+// The zero value for list is an empty list ready to use.
+type list struct {
+	root cacheItem // sentinel list element, only &root, root.prev, and root.next are used
+	len  int       // current list length excluding (this) sentinel element
+}
+
+// Init initializes or clears list l.
+func (l *list) Init() *list {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+// newList returns an initialized list.
+func newList() *list { return new(list).Init() }
+
+// Len returns the number of elements of list l.
+// The complexity is O(1).
+func (l *list) Len() int { return l.len }
+
+// Back returns the last element of list l or nil if the list is empty.
+func (l *list) Back() *cacheItem {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// lazyInit lazily initializes a zero list value.
+func (l *list) lazyInit() {
+	if l.root.next == nil {
+		l.Init()
+	}
+}
+
+// insert inserts e after at and increments l.len
+func (l *list) insert(e, at *cacheItem) {
+	n := at.next
+	at.next = e
+	e.prev = at
+	e.next = n
+	n.prev = e
+	e.list = l
+	l.len++
+}
+
+// insertValue is a convenience wrapper for insert(&cacheItem{value: v}, at).
+func (l *list) insertValue(c, at *cacheItem) {
+	l.insert(c, at)
+}
+
+// remove removes e from its list, decrements l.len, and returns e.
+func (l *list) remove(e *cacheItem) *cacheItem {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	e.list = nil
+	l.len--
+	return e
+}
+
+// move moves e to next to at and returns e.
+func (l *list) move(e, at *cacheItem) *cacheItem {
+	if e == at {
+		return e
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	n := at.next
+	at.next = e
+	e.prev = at
+	e.next = n
+	n.prev = e
+
+	return e
+}
+
+// Remove removes e from l if e is an element of list l.
+// It returns the element value e.value.
+// The element must not be nil.
+func (l *list) Remove(e *cacheItem) interface{} {
+	if e.list == l {
+		// if e.list == l, l must have been initialized when e was inserted
+		// in l or l == nil (e is a zero cacheItem) and l.remove will crash
+		l.remove(e)
+	}
+	return e.value
+}
+
+// PushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *list) PushFront(c *cacheItem) {
+	l.lazyInit()
+	l.insertValue(c, &l.root)
+}
+
+// MoveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *list) MoveToFront(e *cacheItem) {
+	if e.list != l || l.root.next == e {
+		return
+	}
+	// see comment in list.Remove about initialization of l
+	l.move(e, &l.root)
+}

--- a/internal/cache/list_test.go
+++ b/internal/cache/list_test.go
@@ -1,0 +1,110 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the lists_LICENSE file.
+
+package cache
+
+import (
+	"testing"
+)
+
+func checkListLen(t *testing.T, l *list, length int) bool {
+	if n := l.Len(); n != length {
+		t.Errorf("l.Len() = %d, want %d", n, length)
+		return false
+	}
+	return true
+}
+
+func checkListPointers(t *testing.T, l *list, es []*cacheItem) {
+	root := &l.root
+
+	if !checkListLen(t, l, len(es)) {
+		return
+	}
+
+	// zero length lists must be the zero value or properly initialized (sentinel circle)
+	if len(es) == 0 {
+		if l.root.next != nil && l.root.next != root || l.root.prev != nil && l.root.prev != root {
+			t.Errorf("l.root.next = %p, l.root.prev = %p; both should both be nil or %p", l.root.next, l.root.prev, root)
+		}
+		return
+	}
+	// len(es) > 0
+
+	// check internal and external prev/next connections
+	for i, e := range es {
+		prev := root
+		Prev := (*cacheItem)(nil)
+		if i > 0 {
+			prev = es[i-1]
+			Prev = prev
+		}
+		if p := e.prev; p != prev {
+			t.Errorf("elt[%d](%p).prev = %p, want %p", i, e, p, prev)
+		}
+		if p := e.Prev(); p != Prev {
+			t.Errorf("elt[%d](%p).Prev() = %p, want %p", i, e, p, Prev)
+		}
+
+		next := root
+		Next := (*cacheItem)(nil)
+		if i < len(es)-1 {
+			next = es[i+1]
+			Next = next
+		}
+		if n := e.next; n != next {
+			t.Errorf("elt[%d](%p).next = %p, want %p", i, e, n, next)
+		}
+		if n := e.Next(); n != Next {
+			t.Errorf("elt[%d](%p).Next() = %p, want %p", i, e, n, Next)
+		}
+	}
+}
+
+func TestList(t *testing.T) {
+	l := newList()
+	checkListPointers(t, l, []*cacheItem{})
+
+	// Single element list
+	e := &cacheItem{value: "a"}
+	l.PushFront(e)
+	checkListPointers(t, l, []*cacheItem{e})
+	l.MoveToFront(e)
+	checkListPointers(t, l, []*cacheItem{e})
+	l.Remove(e)
+	checkListPointers(t, l, []*cacheItem{})
+
+	// Bigger list
+	e4 := &cacheItem{value: 2}
+	e3 := &cacheItem{value: 2}
+	e2 := &cacheItem{value: 2}
+	e1 := &cacheItem{value: 1}
+	l.PushFront(e4)
+	l.PushFront(e3)
+	l.PushFront(e2)
+	l.PushFront(e1)
+	checkListPointers(t, l, []*cacheItem{e1, e2, e3, e4})
+
+	l.Remove(e2)
+	checkListPointers(t, l, []*cacheItem{e1, e3, e4})
+
+	// Check standard iteration.
+	sum := 0
+	for e := l.Back(); e != nil; e = e.Prev() {
+		if i, ok := e.value.(int); ok {
+			sum += i
+		}
+	}
+	if sum != 5 {
+		t.Errorf("sum over l = %d, want 4", sum)
+	}
+
+	// Clear all elements by iterating
+	var next *cacheItem
+	for e := l.Back(); e != nil; e = next {
+		next = e.Prev()
+		l.Remove(e)
+	}
+	checkListPointers(t, l, []*cacheItem{})
+}

--- a/internal/cache/lists_LICENSE
+++ b/internal/cache/lists_LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/cache/options.go
+++ b/internal/cache/options.go
@@ -13,7 +13,7 @@ func OnEvicted(fn func(key string, value interface{})) Option {
 	}
 }
 
-// PurgeEvery functional option defines purge interval
+// PurgeEvery functional option defines deleteExpired interval
 // by default it is 0, i.e. never. If MaxKeys set to any non-zero this default will be 5minutes
 func PurgeEvery(interval time.Duration) Option {
 	return func(lc *LoadingCache) error {
@@ -41,7 +41,7 @@ func TTL(ttl time.Duration) Option {
 	}
 }
 
-// LRU sets cache to LRU (Least Recently Used) eviction mode. Affects size-based purge only.
+// LRU sets cache to LRU (Least Recently Used) eviction mode.
 func LRU() Option {
 	return func(lc *LoadingCache) error {
 		lc.isLRU = true

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"sort"
 	"sync/atomic"
 	"testing"
 
@@ -32,7 +31,6 @@ func TestLruCache_MaxKeys(t *testing.T) {
 	}
 
 	keys := lc.Keys()
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	assert.EqualValues(t, []string{"key-0", "key-1", "key-2", "key-3", "key-4"}, keys)
 
 	// check if really cached

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -48,7 +48,7 @@ func TestLruCache_MaxKeys(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "result-X", res.(string))
-	assert.Equal(t, 5, lc.backend.Len())
+	assert.Equal(t, 5, lc.backend.ItemCount())
 
 	// put to cache and make sure it cached
 	res, err = lc.Get("key-Z", func() (Value, error) {
@@ -62,7 +62,14 @@ func TestLruCache_MaxKeys(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "result-Z", res.(string), "got cached value")
-	assert.Equal(t, 5, lc.backend.Len())
+	assert.Equal(t, 5, lc.backend.ItemCount())
+
+	// first inserted item should be evicted by now
+	res, err = lc.Get("key-1", func() (Value, error) {
+		return "result-blah", nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "result-blah", res.(string), "should not be cached")
 }
 
 func TestLruCache_BadOptions(t *testing.T) {


### PR DESCRIPTION
Same as #20 but with list embedded to make it support `*cacheItem`.