### PR TITLE
Drop LRU from internal cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Loading Cache Wrapper [![Build Status](https://github.com/go-pkgz/lcw/workflows/build/badge.svg)](https://github.com/go-pkgz/lcw/actions) [![Coverage Status](https://coveralls.io/repos/github/go-pkgz/lcw/badge.svg?branch=master)](https://coveralls.io/github/go-pkgz/lcw?branch=master) [![godoc](https://godoc.org/github.com/go-pkgz/lcw?status.svg)](https://godoc.org/github.com/go-pkgz/lcw)
 
 
-The library adds a thin layer on top of [lru cache](https://github.com/hashicorp/golang-lru) and [patrickmn/go-cache](https://github.com/patrickmn/go-cache).
+The library adds a thin layer on top of [lru cache](https://github.com/hashicorp/golang-lru) and internal implementation of expirable cache.
 
 | Cache name     | Constructor           | Defaults          | Description             |
 | -------------- | --------------------- | ----------------- | ----------------------- |

--- a/cache.go
+++ b/cache.go
@@ -1,4 +1,4 @@
-// Package lcw adds a thin layer on top of lru cache and go-cache providing more limits and common interface.
+// Package lcw adds a thin layer on top of lru and expirable cache providing more limits and common interface.
 // The primary method to get (and set) data to/from the cache is LoadingCache.Get returning stored data for a given key or
 // call provided func to retrieve and store, similar to Guava loading cache.
 // Limits allow max values for key size, number of keys, value size and total size of values in the cache.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -172,7 +172,12 @@ func (c *LoadingCache) getValue(key string) (interface{}, bool) {
 func (c *LoadingCache) Purge() {
 	c.Lock()
 	defer c.Unlock()
-	c.purge(allKeys)
+	for k, v := range c.data {
+		delete(c.data, k)
+		if c.onEvicted != nil {
+			c.onEvicted(k, v.data)
+		}
+	}
 }
 
 // DeleteExpired clears cache of expired items

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -31,7 +31,6 @@ func TestLoadingCacheNoPurge(t *testing.T) {
 func TestLoadingCacheWithPurge(t *testing.T) {
 	var evicted []string
 	lc, err := NewLoadingCache(
-		LRU(),
 		PurgeEvery(time.Millisecond*100),
 		TTL(150*time.Millisecond),
 		OnEvicted(func(key string, value interface{}) { evicted = append(evicted, key, value.(string)) }),
@@ -60,15 +59,21 @@ func TestLoadingCacheWithPurge(t *testing.T) {
 	lc.Set("key2", "val2")
 	assert.Equal(t, 1, lc.ItemCount())
 
-	// DeleteExpired, nothing deleted
+	time.Sleep(200 * time.Millisecond) // expire key2
+
+	// DeleteExpired, key2 deleted
 	lc.DeleteExpired()
+	assert.Equal(t, 0, lc.ItemCount())
+	assert.Equal(t, []string{"key1", "val1", "key2", "val2"}, evicted)
+
+	// add third entry
+	lc.Set("key3", "val3")
 	assert.Equal(t, 1, lc.ItemCount())
-	assert.Equal(t, []string{"key1", "val1"}, evicted)
 
 	// Purge, cache should be clean
 	lc.Purge()
 	assert.Equal(t, 0, lc.ItemCount())
-	assert.Equal(t, []string{"key1", "val1", "key2", "val2"}, evicted)
+	assert.Equal(t, []string{"key1", "val1", "key2", "val2", "key3", "val3"}, evicted)
 }
 
 func TestLoadingCacheWithPurgeEnforcedBySize(t *testing.T) {
@@ -105,28 +110,6 @@ func TestLoadingCacheWithPurgeMax(t *testing.T) {
 	assert.False(t, found, "key1 should be deleted")
 }
 
-func TestLoadingCacheWithPurgeMaxLru(t *testing.T) {
-	lc, err := NewLoadingCache(PurgeEvery(time.Millisecond*50), MaxKeys(2), LRU())
-	assert.NoError(t, err)
-	defer lc.Close()
-
-	lc.Set("key1", "val1")
-	lc.Set("key2", "val2")
-	lc.Set("key3", "val3")
-	assert.Equal(t, 3, lc.ItemCount())
-
-	// read key1 again, changes LRU
-	v, ok := lc.Get("key1")
-	assert.Equal(t, "val1", v)
-	assert.True(t, ok)
-
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 2, lc.ItemCount())
-
-	_, found := lc.Get("key2")
-	assert.False(t, found, "key2 should be deleted")
-}
-
 func TestLoadingCacheConcurrency(t *testing.T) {
 	lc, err := NewLoadingCache()
 	assert.NoError(t, err)
@@ -144,7 +127,7 @@ func TestLoadingCacheConcurrency(t *testing.T) {
 
 func TestLoadingCacheInvalidateAndEvict(t *testing.T) {
 	var evicted int
-	lc, err := NewLoadingCache(LRU(), OnEvicted(func(_ string, _ interface{}) { evicted++ }))
+	lc, err := NewLoadingCache(OnEvicted(func(_ string, _ interface{}) { evicted++ }))
 	assert.NoError(t, err)
 
 	lc.Set("key1", "val1")

--- a/internal/cache/options.go
+++ b/internal/cache/options.go
@@ -40,11 +40,3 @@ func TTL(ttl time.Duration) Option {
 		return nil
 	}
 }
-
-// LRU sets cache to LRU (Least Recently Used) eviction mode. Affects size-based purge only.
-func LRU() Option {
-	return func(lc *LoadingCache) error {
-		lc.isLRU = true
-		return nil
-	}
-}


### PR DESCRIPTION
Drop LRU from the internal cache and also simplify purge to prevent items sorting while doing it.