### PR TITLE
Basic support for distributed cache for LRU and Expirable caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: start Redis
+        uses: supercharge/redis-github-action@1.1.0
+
       - name: build and test
         run: |
           go get -v
@@ -29,6 +32,7 @@ jobs:
         env:
           GO111MODULE: "on"
           TZ: "America/Chicago"
+          ENABLE_REDIS_TESTS: "true"
 
       - name: install golangci-lint and goveralls
         run: |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Main features:
 
 ## Usage
 
-```
-cache := lcw.NewLruCache(lcw.MaxKeys(500), lcw.MaxCacheSize(65536), lcw.MaxValSize(200), lcw.MaxKeySize(32))
+```go
+cache, err := lcw.NewLruCache(lcw.MaxKeys(500), lcw.MaxCacheSize(65536), lcw.MaxValSize(200), lcw.MaxKeySize(32))
+if err != nil {
+    panic("failed to create cache")
+}
 defer cache.Close()
 
 val, err := cache.Get("key123", func() (lcw.Value, error) {
@@ -59,7 +62,7 @@ Cache can be created with URIs:
 1. Key is not a string, but a composed type made from partition, key-id and list of scopes (tags). 
 1. Value type limited to `[]byte`
 1. Added `Flush` method for scoped/tagged invalidation of multiple records in a given partition
-1. A simplified interface with Get, Stat and Flush only.
+1. A simplified interface with Get, Stat, Flush and Close only.
 
 ## Details
 

--- a/cache.go
+++ b/cache.go
@@ -83,3 +83,4 @@ func (n *Nop) Stat() CacheStat {
 func (n *Nop) Close() error {
 	return nil
 }
+

--- a/cache.go
+++ b/cache.go
@@ -6,6 +6,8 @@
 // 3 flavors of cache provided - NoP (do-nothing cache), ExpirableCache (TTL based), and LruCache
 package lcw
 
+//go:generate sh -c "mockery -inpkg -name LoadingCache -print > /tmp/cache-mock.tmp && mv /tmp/cache-mock.tmp cache_mock.go"
+
 import (
 	"fmt"
 )

--- a/cache_test.go
+++ b/cache_test.go
@@ -668,7 +668,7 @@ func (m *mockPubSub) Subscribe(fn func(fromID string, key string)) error {
 	return nil
 }
 
-func (m *mockPubSub) Publish(fromID string, key string) error {
+func (m *mockPubSub) Publish(fromID, key string) error {
 	m.calledKeys = append(m.calledKeys, key)
 	for _, fn := range m.fns {
 		fn(fromID, key)

--- a/cache_test.go
+++ b/cache_test.go
@@ -659,7 +659,7 @@ func (s sizedString) MarshalBinary() (data []byte, err error) {
 
 type mockPubSub struct {
 	calledKeys []string
-	fns        []func(fromID string, key string)
+	fns        []func(fromID, key string)
 	sync.Mutex
 	sync.WaitGroup
 }
@@ -670,7 +670,7 @@ func (m *mockPubSub) CalledKeys() []string {
 	return m.calledKeys
 }
 
-func (m *mockPubSub) Subscribe(fn func(fromID string, key string)) error {
+func (m *mockPubSub) Subscribe(fn func(fromID, key string)) error {
 	m.Lock()
 	defer m.Unlock()
 	m.fns = append(m.fns, fn)

--- a/cache_test.go
+++ b/cache_test.go
@@ -671,7 +671,8 @@ func (m *mockPubSub) Subscribe(fn func(fromID string, key string)) error {
 func (m *mockPubSub) Publish(fromID, key string) error {
 	m.calledKeys = append(m.calledKeys, key)
 	for _, fn := range m.fns {
-		fn(fromID, key)
+		// run in goroutine to prevent deadlock
+		go fn(fromID, key)
 		log.Println("!!!", fromID, key)
 	}
 	return nil

--- a/cache_test.go
+++ b/cache_test.go
@@ -656,3 +656,21 @@ func (s sizedString) Size() int { return len(s) }
 func (s sizedString) MarshalBinary() (data []byte, err error) {
 	return []byte(s), nil
 }
+
+type mockPubSub struct {
+	calledKeys []string
+	fns        []func(fromID string, key string)
+}
+
+func (m *mockPubSub) Subscribe(fn func(fromID string, key string)) error {
+	m.fns = append(m.fns, fn)
+	return nil
+}
+
+func (m *mockPubSub) Publish(fromID string, key string) error {
+	m.calledKeys = append(m.calledKeys, key)
+	for _, fn := range m.fns {
+		fn(fromID, key)
+	}
+	return nil
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -3,6 +3,7 @@ package lcw
 import (
 	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"strings"
 	"sync"
@@ -671,6 +672,7 @@ func (m *mockPubSub) Publish(fromID string, key string) error {
 	m.calledKeys = append(m.calledKeys, key)
 	for _, fn := range m.fns {
 		fn(fromID, key)
+		log.Println("!!!", fromID, key)
 	}
 	return nil
 }

--- a/eventbus/pubsub.go
+++ b/eventbus/pubsub.go
@@ -1,5 +1,10 @@
+// Package eventbus provides PubSub interface used for distributed cache invalidation,
+// as well as NopPubSub implementation.
 package eventbus
 
+// PubSub interface is used for distributed cache invalidation.
+// Publish is called on each entry invalidation,
+// Subscribe is used for subscription for these events.
 type PubSub interface {
 	Publish(fromID string, key string) error
 	Subscribe(fn func(fromID string, key string)) error
@@ -8,10 +13,12 @@ type PubSub interface {
 // NopPubSub implements default do-nothing pub-sub (event bus)
 type NopPubSub struct{}
 
+// Subscribe does nothing for NopPubSub
 func (n *NopPubSub) Subscribe(fn func(fromID string, key string)) error {
 	return nil
 }
 
-func (n *NopPubSub) Publish(fromID string, key string) error {
+// Publish does nothing for NopPubSub
+func (n *NopPubSub) Publish(fromID, key string) error {
 	return nil
 }

--- a/eventbus/pubsub.go
+++ b/eventbus/pubsub.go
@@ -1,5 +1,5 @@
 // Package eventbus provides PubSub interface used for distributed cache invalidation,
-// as well as NopPubSub implementation.
+// as well as NopPubSub and RedisPubSub implementations.
 package eventbus
 
 // PubSub interface is used for distributed cache invalidation.

--- a/eventbus/pubsub.go
+++ b/eventbus/pubsub.go
@@ -1,0 +1,17 @@
+package eventbus
+
+type PubSub interface {
+	Publish(fromID string, key string) error
+	Subscribe(fn func(fromID string, key string)) error
+}
+
+// NopPubSub implements default do-nothing pub-sub (event bus)
+type NopPubSub struct{}
+
+func (n *NopPubSub) Subscribe(fn func(fromID string, key string)) error {
+	return nil
+}
+
+func (n *NopPubSub) Publish(fromID string, key string) error {
+	return nil
+}

--- a/eventbus/pubsub.go
+++ b/eventbus/pubsub.go
@@ -6,15 +6,15 @@ package eventbus
 // Publish is called on each entry invalidation,
 // Subscribe is used for subscription for these events.
 type PubSub interface {
-	Publish(fromID string, key string) error
-	Subscribe(fn func(fromID string, key string)) error
+	Publish(fromID, key string) error
+	Subscribe(fn func(fromID, key string)) error
 }
 
 // NopPubSub implements default do-nothing pub-sub (event bus)
 type NopPubSub struct{}
 
 // Subscribe does nothing for NopPubSub
-func (n *NopPubSub) Subscribe(fn func(fromID string, key string)) error {
+func (n *NopPubSub) Subscribe(fn func(fromID, key string)) error {
 	return nil
 }
 

--- a/eventbus/pubsub_test.go
+++ b/eventbus/pubsub_test.go
@@ -1,0 +1,13 @@
+package eventbus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNopPubSub(t *testing.T) {
+	nopPubSub := NopPubSub{}
+	assert.NoError(t, nopPubSub.Subscribe(nil))
+	assert.NoError(t, nopPubSub.Publish("", ""))
+}

--- a/eventbus/redis.go
+++ b/eventbus/redis.go
@@ -31,8 +31,8 @@ type RedisPubSub struct {
 }
 
 // Subscribe calls provided function on subscription channel provided on new RedisPubSub instance creation.
-// Should not be called more than once. Spawns a gorouting and does not return an error.
-func (m *RedisPubSub) Subscribe(fn func(fromID string, key string)) error {
+// Should not be called more than once. Spawns a goroutine and does not return an error.
+func (m *RedisPubSub) Subscribe(fn func(fromID, key string)) error {
 	go func(done <-chan struct{}, pubsub *redis.PubSub) {
 		for {
 			select {
@@ -48,7 +48,7 @@ func (m *RedisPubSub) Subscribe(fn func(fromID string, key string)) error {
 			// Process the message
 			if msg, ok := msg.(*redis.Message); ok {
 				payload := strings.Split(msg.Payload, "$")
-				fn(payload[0], payload[1])
+				fn(payload[0], strings.Join(payload[1:], "$"))
 			}
 		}
 	}(m.done, m.pubSub)

--- a/eventbus/redis.go
+++ b/eventbus/redis.go
@@ -1,0 +1,71 @@
+package eventbus
+
+import (
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis/v7"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+// NewRedisPubSub creates new RedisPubSub with given parameters.
+// Returns an error in case of problems with creating PubSub client for specified channel.
+func NewRedisPubSub(addr, channel string) (*RedisPubSub, error) {
+	client := redis.NewClient(&redis.Options{Addr: addr})
+	pubSub := client.Subscribe(channel)
+	// wait for subscription to be created and ignore the message
+	if _, err := pubSub.Receive(); err != nil {
+		return nil, errors.Wrapf(err, "problem subscribing to channel %s on address %s", channel, addr)
+	}
+	return &RedisPubSub{client: client, pubSub: pubSub, channel: channel, done: make(chan struct{})}, nil
+}
+
+// RedisPubSub provides Redis implementation for PubSub interface
+type RedisPubSub struct {
+	client  *redis.Client
+	pubSub  *redis.PubSub
+	channel string
+
+	done chan struct{}
+}
+
+// Subscribe calls provided function on subscription channel provided on new RedisPubSub instance creation.
+// Should not be called more than once. Spawns a gorouting and does not return an error.
+func (m *RedisPubSub) Subscribe(fn func(fromID string, key string)) error {
+	go func(done <-chan struct{}, pubsub *redis.PubSub) {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			msg, err := pubsub.ReceiveTimeout(time.Second * 10)
+			if err != nil {
+				continue
+			}
+
+			// Process the message
+			if msg, ok := msg.(*redis.Message); ok {
+				payload := strings.Split(msg.Payload, "$")
+				fn(payload[0], payload[1])
+			}
+		}
+	}(m.done, m.pubSub)
+
+	return nil
+}
+
+// Publish publishes provided message to channel provided on new RedisPubSub instance creation
+func (m *RedisPubSub) Publish(fromID, key string) error {
+	return m.client.Publish(m.channel, fromID+"$"+key).Err()
+}
+
+// Close cleans up running goroutines and closes Redis clients
+func (m *RedisPubSub) Close() error {
+	close(m.done)
+	errs := new(multierror.Error)
+	errs = multierror.Append(errs, errors.Wrap(m.pubSub.Close(), "problem closing pubSub client"))
+	errs = multierror.Append(errs, errors.Wrap(m.client.Close(), "problem closing redis client"))
+	return errs.ErrorOrNil()
+}

--- a/eventbus/redis_test.go
+++ b/eventbus/redis_test.go
@@ -27,12 +27,12 @@ func TestRedisPubSub(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, redisPubSub)
 	var called []string
-	assert.Nil(t, redisPubSub.Subscribe(func(fromID string, key string) {
+	assert.Nil(t, redisPubSub.Subscribe(func(fromID, key string) {
 		called = append(called, fromID, key)
 	}))
-	assert.NoError(t, redisPubSub.Publish("test_fromID", "test_key"))
+	assert.NoError(t, redisPubSub.Publish("test_fromID", "$test$key$"))
 	// Sleep which waits for Subscribe goroutine to pick up published changes
 	time.Sleep(time.Second)
 	assert.NoError(t, redisPubSub.Close())
-	assert.Equal(t, []string{"test_fromID", "test_key"}, called)
+	assert.Equal(t, []string{"test_fromID", "$test$key$"}, called)
 }

--- a/eventbus/redis_test.go
+++ b/eventbus/redis_test.go
@@ -1,0 +1,38 @@
+package eventbus
+
+import (
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRedisPubSub_Error(t *testing.T) {
+	redisPubSub, err := NewRedisPubSub("127.0.0.1:99999", "test")
+	require.Error(t, err)
+	require.Nil(t, redisPubSub)
+}
+
+func TestRedisPubSub(t *testing.T) {
+	if _, ok := os.LookupEnv("ENABLE_REDIS_TESTS"); !ok {
+		t.Skip("ENABLE_REDIS_TESTS env variable is not set, not expecting Redis to be ready at 127.0.0.1:6379")
+	}
+
+	channel := "lcw-test-" + strconv.Itoa(rand.Intn(1000000))
+	redisPubSub, err := NewRedisPubSub("127.0.0.1:6379", channel)
+	require.NoError(t, err)
+	require.NotNil(t, redisPubSub)
+	var called []string
+	assert.Nil(t, redisPubSub.Subscribe(func(fromID string, key string) {
+		called = append(called, fromID, key)
+	}))
+	assert.NoError(t, redisPubSub.Publish("test_fromID", "test_key"))
+	// Sleep which waits for Subscribe goroutine to pick up published changes
+	time.Sleep(time.Second)
+	assert.NoError(t, redisPubSub.Close())
+	assert.Equal(t, []string{"test_fromID", "test_key"}, called)
+}

--- a/expirable_cache.go
+++ b/expirable_cache.go
@@ -54,6 +54,9 @@ func NewExpirableCache(opts ...Option) (*ExpirableCache, error) {
 				size := s.Size()
 				atomic.AddInt64(&res.currentSize, -1*int64(size))
 			}
+			// ignore the error on Publish as we don't have log inside the module and
+			// there is no other way to handle it: we publish the cache invalidation
+			// and hope for the best
 			_ = res.eventBus.Publish(res.id, key)
 		}),
 	)

--- a/expirable_cache.go
+++ b/expirable_cache.go
@@ -138,6 +138,7 @@ func (c *ExpirableCache) Close() error {
 	return nil
 }
 
+// onBusEvent reacts on invalidation message triggered by event bus from another cache instance
 func (c *ExpirableCache) onBusEvent(id, key string) {
 	if id != c.id {
 		c.backend.Invalidate(key)

--- a/expirable_cache_test.go
+++ b/expirable_cache_test.go
@@ -123,6 +123,7 @@ func TestExpirableCacheWithBus(t *testing.T) {
 
 	// add 5 keys to the first node cache
 	for i := 0; i < 5; i++ {
+		i := i
 		_, e := lc1.Get(fmt.Sprintf("key-%d", i), func() (Value, error) {
 			return fmt.Sprintf("result-%d", i), nil
 		})

--- a/expirable_cache_test.go
+++ b/expirable_cache_test.go
@@ -37,7 +37,11 @@ func TestExpirableCache(t *testing.T) {
 	assert.Equal(t, 5, lc.Stat().Keys)
 	assert.Equal(t, int64(6), lc.Stat().Misses)
 
-	time.Sleep(55 * time.Millisecond)
+	// let key-0 expire, GitHub Actions friendly way
+	for lc.Stat().Keys > 4 {
+		lc.backend.DeleteExpired() // enforce DeleteExpired for GitHub earlier than TTL/2
+		time.Sleep(time.Millisecond * 10)
+	}
 	assert.Equal(t, 4, lc.Stat().Keys)
 
 	time.Sleep(210 * time.Millisecond)
@@ -117,9 +121,11 @@ func TestExpirableCacheWithBus(t *testing.T) {
 	ps := &mockPubSub{}
 	lc1, err := NewExpirableCache(MaxKeys(5), TTL(time.Millisecond*100), EventBus(ps))
 	require.NoError(t, err)
+	defer lc1.Close()
 
 	lc2, err := NewExpirableCache(MaxKeys(50), TTL(time.Millisecond*5000), EventBus(ps))
 	require.NoError(t, err)
+	defer lc2.Close()
 
 	// add 5 keys to the first node cache
 	for i := 0; i < 5; i++ {
@@ -131,26 +137,31 @@ func TestExpirableCacheWithBus(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	assert.Equal(t, 0, len(ps.calledKeys), "no events")
+	assert.Equal(t, 0, len(ps.CalledKeys()), "no events")
 	assert.Equal(t, 5, lc1.Stat().Keys)
 	assert.Equal(t, int64(5), lc1.Stat().Misses)
 
 	// add key-1 key to the second node
-	_, e := lc2.Get(fmt.Sprintf("key-1"), func() (Value, error) {
+	_, e := lc2.Get("key-1", func() (Value, error) {
 		return "result-111", nil
 	})
 	assert.NoError(t, e)
 	assert.Equal(t, 1, lc2.Stat().Keys)
 	assert.Equal(t, int64(1), lc2.Stat().Misses, lc2.Stat())
 
-	time.Sleep(55 * time.Millisecond) // let key-1 expire
-	assert.Equal(t, 1, len(ps.calledKeys), "1 event, key-0 expired")
+	// let key-0 expire, GitHub Actions friendly way
+	for lc1.Stat().Keys > 4 {
+		lc1.backend.DeleteExpired() // enforce DeleteExpired for GitHub earlier than TTL/2
+		ps.Wait()                   // wait for onBusEvent goroutines to finish
+		time.Sleep(time.Millisecond * 10)
+	}
 	assert.Equal(t, 4, lc1.Stat().Keys)
 	assert.Equal(t, 1, lc2.Stat().Keys, "key-1 still in cache2")
+	assert.Equal(t, 1, len(ps.CalledKeys()))
 
 	time.Sleep(210 * time.Millisecond) // let all keys expire
-	assert.Equal(t, 6, len(ps.calledKeys), "6 events, key-1 expired %+v", ps.calledKeys)
+	ps.Wait()                          // wait for onBusEvent goroutines to finish
+	assert.Equal(t, 6, len(ps.CalledKeys()), "6 events, key-1 expired %+v", ps.calledKeys)
 	assert.Equal(t, 0, lc1.Stat().Keys)
 	assert.Equal(t, 0, lc2.Stat().Keys, "key-1 removed from cache2")
-
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-pkgz/lcw
 require (
 	github.com/alicebob/miniredis/v2 v2.11.4
 	github.com/go-redis/redis/v7 v7.2.0
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3 h1:6amM4HsNPOvMLVc2ZnyqrjeQ92YAVWn7T4WBKK87inY=
 github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=

--- a/lru_cache.go
+++ b/lru_cache.go
@@ -1,7 +1,6 @@
 package lcw
 
 import (
-	"log"
 	"sync/atomic"
 
 	"github.com/google/uuid"
@@ -151,7 +150,6 @@ func (c *LruCache) Close() error {
 // onBusEvent reacts on invalidation message triggered by event bus from another cache instance
 func (c *LruCache) onBusEvent(id, key string) {
 	if id != c.id && c.backend.Contains(key) { // prevent reaction on event from this cache
-		log.Println("!! ", id, key)
 		c.backend.Remove(key)
 	}
 }

--- a/lru_cache.go
+++ b/lru_cache.go
@@ -17,7 +17,7 @@ type LruCache struct {
 	CacheStat
 	backend     *lru.Cache
 	currentSize int64
-	id          string
+	id          string // uuid identifying cache instance
 }
 
 // NewLruCache makes LRU LoadingCache implementation, 1000 max keys by default
@@ -36,28 +36,33 @@ func NewLruCache(opts ...Option) (*LruCache, error) {
 		}
 	}
 
-	if err := res.eventBus.Subscribe(res.onBusEvent); err != nil {
-		return nil, errors.Wrapf(err, "can't subscribe to event bus")
+	err := res.init()
+	return &res, err
+}
+
+func (c *LruCache) init() error {
+	if err := c.eventBus.Subscribe(c.onBusEvent); err != nil {
+		return errors.Wrapf(err, "can't subscribe to event bus")
 	}
 
 	onEvicted := func(key interface{}, value interface{}) {
-		if res.onEvicted != nil {
-			res.onEvicted(key.(string), value)
+		if c.onEvicted != nil {
+			c.onEvicted(key.(string), value)
 		}
 		if s, ok := value.(Sizer); ok {
 			size := s.Size()
-			atomic.AddInt64(&res.currentSize, -1*int64(size))
+			atomic.AddInt64(&c.currentSize, -1*int64(size))
 		}
-		_ = res.eventBus.Publish(res.id, key.(string))
+		_ = c.eventBus.Publish(c.id, key.(string)) // signal invalidation to other nodes
 	}
 
 	var err error
 	// OnEvicted called automatically for expired and manually deleted
-	if res.backend, err = lru.NewWithEvict(res.maxKeys, onEvicted); err != nil {
-		return nil, errors.Wrap(err, "failed to make lru cache backend")
+	if c.backend, err = lru.NewWithEvict(c.maxKeys, onEvicted); err != nil {
+		return errors.Wrap(err, "failed to make lru cache backend")
 	}
 
-	return &res, nil
+	return nil
 }
 
 // Get gets value by key or load with fn if not found in cache
@@ -143,9 +148,10 @@ func (c *LruCache) Close() error {
 	return nil
 }
 
+// onBusEvent reacts on invalidation message triggered by event bus from another cache instance
 func (c *LruCache) onBusEvent(id, key string) {
-	log.Println("!! ", id, key)
-	if id != c.id { // prevent reaction on event from this cache
+	if id != c.id && c.backend.Contains(key) { // prevent reaction on event from this cache
+		log.Println("!! ", id, key)
 		c.backend.Remove(key)
 	}
 }

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -4,14 +4,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sort"
+	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-pkgz/lcw/eventbus"
 )
 
 func TestLruCache_MaxKeys(t *testing.T) {
@@ -87,11 +93,11 @@ func TestLruCache_MaxKeysWithBus(t *testing.T) {
 
 	var coldCalls int32
 	lc1, err := NewLruCache(MaxKeys(5), MaxValSize(10), EventBus(ps))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer lc1.Close()
 
 	lc2, err := NewLruCache(MaxKeys(50), MaxValSize(100), EventBus(ps))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer lc2.Close()
 
 	// put 5 keys to cache1
@@ -146,6 +152,75 @@ func TestLruCache_MaxKeysWithBus(t *testing.T) {
 	ps.Wait()
 
 	assert.Equal(t, 0, lc2.backend.Len(), "cache2 removed key-1")
+}
+
+func TestLruCache_MaxKeysWithRedis(t *testing.T) {
+	if _, ok := os.LookupEnv("ENABLE_REDIS_TESTS"); !ok {
+		t.Skip("ENABLE_REDIS_TESTS env variable is not set, not expecting Redis to be ready at 127.0.0.1:6379")
+	}
+
+	var coldCalls int32
+
+	channel := "lcw-test-" + strconv.Itoa(rand.Intn(1000000))
+
+	redisPubSub1, err := eventbus.NewRedisPubSub("127.0.0.1:6379", channel)
+	require.NoError(t, err)
+	lc1, err := NewLruCache(MaxKeys(5), MaxValSize(10), EventBus(redisPubSub1))
+	require.NoError(t, err)
+	defer lc1.Close()
+
+	redisPubSub2, err := eventbus.NewRedisPubSub("127.0.0.1:6379", channel)
+	require.NoError(t, err)
+	lc2, err := NewLruCache(MaxKeys(50), MaxValSize(100), EventBus(redisPubSub2))
+	require.NoError(t, err)
+	defer lc2.Close()
+
+	// put 5 keys to cache1
+	for i := 0; i < 5; i++ {
+		i := i
+		res, e := lc1.Get(fmt.Sprintf("key-%d", i), func() (Value, error) {
+			atomic.AddInt32(&coldCalls, 1)
+			return fmt.Sprintf("result-%d", i), nil
+		})
+		assert.NoError(t, e)
+		assert.Equal(t, fmt.Sprintf("result-%d", i), res.(string))
+		assert.Equal(t, int32(i+1), atomic.LoadInt32(&coldCalls))
+	}
+	// check if really cached
+	res, err := lc1.Get("key-3", func() (Value, error) {
+		return "result-blah", nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "result-3", res.(string), "should be cached")
+
+	// put 1 key to cache2
+	res, e := lc2.Get("key-1", func() (Value, error) {
+		return "result-111", nil
+	})
+	assert.NoError(t, e)
+	assert.Equal(t, "result-111", res.(string))
+
+	// try to cache1 after maxKeys reached, will remove key-0
+	res, err = lc1.Get("key-X", func() (Value, error) {
+		return "result-X", nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "result-X", res.(string))
+	assert.Equal(t, 5, lc1.backend.Len())
+
+	assert.Equal(t, 1, lc2.backend.Len(), "cache2 still has key-1")
+
+	// try to cache1 after maxKeys reached, will remove key-1
+	res, err = lc1.Get("key-X2", func() (Value, error) {
+		return "result-X", nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "result-X", res.(string))
+
+	time.Sleep(time.Second)
+	assert.Equal(t, 0, lc2.backend.Len(), "cache2 removed key-1")
+	assert.NoError(t, redisPubSub1.Close())
+	assert.NoError(t, redisPubSub2.Close())
 }
 
 // LruCache illustrates the use of LRU loading cache

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -94,6 +94,7 @@ func TestLruCache_MaxKeysWithBus(t *testing.T) {
 
 	// put 5 keys to cache1
 	for i := 0; i < 5; i++ {
+		i := i
 		res, e := lc1.Get(fmt.Sprintf("key-%d", i), func() (Value, error) {
 			atomic.AddInt32(&coldCalls, 1)
 			return fmt.Sprintf("result-%d", i), nil
@@ -131,6 +132,7 @@ func TestLruCache_MaxKeysWithBus(t *testing.T) {
 		return "result-X", nil
 	})
 	assert.Nil(t, err)
+	assert.Equal(t, "result-2", res.(string))
 	assert.Equal(t, 1, lc2.backend.Len(), "cache2 removed key-1")
 }
 

--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -83,7 +83,6 @@ func TestLruCache_BadOptions(t *testing.T) {
 }
 
 func TestLruCache_MaxKeysWithBus(t *testing.T) {
-
 	ps := &mockPubSub{}
 
 	var coldCalls int32

--- a/options.go
+++ b/options.go
@@ -88,7 +88,7 @@ func OnEvicted(fn func(key string, value Value)) Option {
 	}
 }
 
-// OnEvicted sets callback on invalidation event
+// EventBus sets PubSub for distributed cache invalidation
 func EventBus(pubsub eventbus.PubSub) Option {
 	return func(o *options) error {
 		o.eventBus = pubsub

--- a/options.go
+++ b/options.go
@@ -3,6 +3,8 @@ package lcw
 import (
 	"errors"
 	"time"
+
+	"github.com/go-pkgz/lcw/eventbus"
 )
 
 type options struct {
@@ -12,6 +14,7 @@ type options struct {
 	maxCacheSize int64
 	ttl          time.Duration
 	onEvicted    func(key string, value Value)
+	eventBus     eventbus.PubSub
 }
 
 // Option func type
@@ -81,6 +84,14 @@ func TTL(ttl time.Duration) Option {
 func OnEvicted(fn func(key string, value Value)) Option {
 	return func(o *options) error {
 		o.onEvicted = fn
+		return nil
+	}
+}
+
+// OnEvicted sets callback on invalidation event
+func EventBus(pubsub eventbus.PubSub) Option {
+	return func(o *options) error {
+		o.eventBus = pubsub
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -89,9 +89,9 @@ func OnEvicted(fn func(key string, value Value)) Option {
 }
 
 // EventBus sets PubSub for distributed cache invalidation
-func EventBus(pubsub eventbus.PubSub) Option {
+func EventBus(pubSub eventbus.PubSub) Option {
 	return func(o *options) error {
-		o.eventBus = pubsub
+		o.eventBus = pubSub
 		return nil
 	}
 }


### PR DESCRIPTION
Adds support of distributed cache invalidation using the PubSub interface. It seems to make sense to implement it only for local LRU and Expirable cache, but not for Redis or SCache. 

Test with example Redis implementation is added as well and invoked from CI.

Resolves #8.