### PR TITLE
add Close method to SCache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: install golangci-lint and goveralls
         run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.25.0
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.26.0
           GO111MODULE=off go get -u -v github.com/mattn/goveralls
 
       - name: run linters

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Main features:
 
 ```
 cache := lcw.NewLruCache(lcw.MaxKeys(500), lcw.MaxCacheSize(65536), lcw.MaxValSize(200), lcw.MaxKeySize(32))
+defer cache.Close()
 
 val, err := cache.Get("key123", func() (lcw.Value, error) {
     res, err := getDataFromSomeSource(params) // returns string

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -189,9 +189,9 @@ func (c *LoadingCache) Close() {
 	close(c.done)
 }
 
-// keysWithTs includes list of keys with ts. This is for sorting keys
+// keysWithTS includes list of keys with ts. This is for sorting keys
 // in order to provide least recently added sorting for size-based eviction
-type keysWithTs []struct {
+type keysWithTS []struct {
 	key string
 	ts  time.Time
 }
@@ -199,7 +199,7 @@ type keysWithTs []struct {
 // purge records > maxKeys. Has to be called with lock!
 // call with maxKeys 0 will only clear expired entries.
 func (c *LoadingCache) purge(maxKeys int64) {
-	kts := keysWithTs{}
+	kts := keysWithTS{}
 
 	for key, value := range c.data {
 		// ttl eviction
@@ -210,7 +210,7 @@ func (c *LoadingCache) purge(maxKeys int64) {
 			}
 		}
 
-		// prepare list of keysWithTs for size eviction
+		// prepare list of keysWithTS for size eviction
 		if maxKeys > 0 && int64(len(c.data)) > maxKeys {
 			ts := c.data[key].expiresAt
 

--- a/scache.go
+++ b/scache.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Scache wraps LoadingCache with partitions (sub-system), and scopes.
-// Simplified interface with just 3 funcs - Get, Flush and Stats
+// Simplified interface with just 4 funcs - Get, Flush, Stats and Close
 type Scache struct {
 	lc LoadingCache
 }
@@ -29,6 +29,11 @@ func (m *Scache) Get(key Key, fn func() ([]byte, error)) (data []byte, err error
 // Stat delegates the call to the underlying cache backend
 func (m *Scache) Stat() CacheStat {
 	return m.lc.Stat()
+}
+
+// Close calls Close function of the underlying cache
+func (m *Scache) Close() error {
+	return m.lc.Close()
 }
 
 // Flush clears cache and calls postFlushFn async

--- a/scache_test.go
+++ b/scache_test.go
@@ -20,6 +20,7 @@ func TestScache_Get(t *testing.T) {
 	lru, err := NewLruCache()
 	require.NoError(t, err)
 	lc := NewScache(lru)
+	defer lc.Close()
 
 	var coldCalls int32
 
@@ -52,6 +53,7 @@ func TestScache_Scopes(t *testing.T) {
 	lru, err := NewLruCache()
 	require.NoError(t, err)
 	lc := NewScache(lru)
+	defer lc.Close()
 
 	res, err := lc.Get(NewKey("site").ID("key").Scopes("s1", "s2"), func() ([]byte, error) {
 		return []byte("value"), nil
@@ -250,6 +252,7 @@ func ExampleScache() {
 	}
 
 	cache := NewScache(backend)
+	defer cache.Close()
 
 	// url not in cache, load data
 	url := ts.URL + "/post/42"

--- a/scache_test.go
+++ b/scache_test.go
@@ -252,7 +252,6 @@ func ExampleScache() {
 	}
 
 	cache := NewScache(backend)
-	defer cache.Close()
 
 	// url not in cache, load data
 	url := ts.URL + "/post/42"
@@ -289,8 +288,12 @@ func ExampleScache() {
 	stats := cache.Stat()
 	fmt.Printf("%+v\n", stats)
 
-	// close test HTTP server after all log.Fatalf are passed
+	// close cache and test HTTP server after all log.Fatalf are passed
 	ts.Close()
+	err = cache.Close()
+	if err != nil {
+		log.Fatalf("can't close cache %v", err)
+	}
 
 	// Output:
 	// <html><body>test response</body></html>


### PR DESCRIPTION
Without this method, it's impossible to close underlying cache without separately saving it.