### PR TITLE
Stop reading eventually consistent size in test

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -225,8 +225,6 @@ func TestCache_MaxCacheSizeParallel(t *testing.T) {
 					})
 					require.NoError(t, err)
 					require.Equal(t, sizedString(fmt.Sprintf("result-%d", i)), res.(sizedString))
-					size := c.size()
-					require.True(t, size < 200 && size >= 0, "unexpected size=%d", size) // won't be exactly 123 due parallel
 				}()
 			}
 			wg.Wait()


### PR DESCRIPTION
Fixes flaps in TestCache_MaxCacheSizeParallel, resolves #28. Kudos to @chychkan for investigation.