### PR TITLE
Make Close operation idempotent

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -185,6 +185,12 @@ func (c *LoadingCache) ItemCount() int {
 func (c *LoadingCache) Close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// don't panic in case service is already closed
+	select {
+	case <-c.done:
+		return
+	default:
+	}
 	close(c.done)
 }
 


### PR DESCRIPTION
Previously, second call of LoadingCache.Close() resulted in panic.