### PR TITLE
redis.UniversalClient as backend

### DIFF
--- a/redis_cache.go
+++ b/redis_cache.go
@@ -17,11 +17,11 @@ const RedisValueSizeLimit = 512 * 1024 * 1024
 type RedisCache struct {
 	options
 	CacheStat
-	backend *redis.Client
+	backend redis.UniversalClient
 }
 
 // NewRedisCache makes Redis LoadingCache implementation.
-func NewRedisCache(backend *redis.Client, opts ...Option) (*RedisCache, error) {
+func NewRedisCache(backend redis.UniversalClient, opts ...Option) (*RedisCache, error) {
 	res := RedisCache{
 		options: options{
 			ttl: 5 * time.Minute,

--- a/v2/redis_cache.go
+++ b/v2/redis_cache.go
@@ -18,12 +18,12 @@ const RedisValueSizeLimit = 512 * 1024 * 1024
 type RedisCache[V any] struct {
 	Workers[V]
 	CacheStat
-	backend *redis.Client
+	backend redis.UniversalClient
 }
 
 // NewRedisCache makes Redis LoadingCache implementation.
 // Supports only string and string-based types and will return error otherwise.
-func NewRedisCache[V any](backend *redis.Client, opts ...Option[V]) (*RedisCache[V], error) {
+func NewRedisCache[V any](backend redis.UniversalClient, opts ...Option[V]) (*RedisCache[V], error) {
 	// check if V is string, not underlying type but directly, and otherwise return error if strToV is nil as it should be defined
 
 	res := RedisCache[V]{


### PR DESCRIPTION
This allows to use either a `redis.ClusterClient`, a `redis.FailoverClient`, or a single-node `redis.Client` as the backend.