### PR TITLE
Fix CI workflow: checkout before setup-go for proper caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
       - name: set up go
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v4
 
       - name: start Redis
         uses: supercharge/redis-github-action@1.8.0
@@ -46,14 +46,14 @@ jobs:
         working-directory: v2
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.6
 
       - name: golangci-lint for v2
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.6
           working-directory: v2
 
       - name: submit coverage

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,44 +1,49 @@
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  gocyclo:
-    min-complexity: 15
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-
+version: "2"
+run:
+  concurrency: 4
 linters:
+  default: none
   enable:
-    - staticcheck
-    - unused
-    - revive
-    - govet
-    - unconvert
-    - gosec
-    - gocyclo
     - dupl
-    - misspell
-    - unparam
-    - typecheck
-    - ineffassign
-    - stylecheck
     - gochecknoinits
-    - exportloopref
     - gocritic
+    - gocyclo
+    - govet
+    - ineffassign
+    - misspell
     - nakedret
-    - gosimple
     - prealloc
-  fast: false
-  disable-all: true
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$

--- a/v2/options.go
+++ b/v2/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-pkgz/lcw/v2/eventbus"
 )
 
+// Workers holds cache configuration options
 type Workers[V any] struct {
 	maxKeys      int
 	maxValueSize int


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- setup-go needs go.mod/go.sum files to generate cache keys
- Update golangci-lint action to v7 and version to v2.6
- Migrate golangci-lint config from v1 to v2 format